### PR TITLE
Fix errors with urlconf patching

### DIFF
--- a/changes/17.bugfix
+++ b/changes/17.bugfix
@@ -1,0 +1,1 @@
+Fix errors with urlconf patching

--- a/docs/addon_configuration.rst
+++ b/docs/addon_configuration.rst
@@ -33,8 +33,8 @@ The following attributes are currently supported:
 * ``installed-apps`` [**required**]: list of django applications to be appended in the project ``INSTALLED_APPS``
   setting. Application must be already installed when the configuration is processed, thus they must declared as
   package dependencies (or depedencies of direct dependencies, even if this is a bit risky);
-* ``urls`` [**required**]: list of urlconfs to be added to the project ``ROOT_URLCONF``. List can be empty if no url
-  configuration is needed.
+* ``urls`` [optional]: list of urlconfs to be added to the project ``ROOT_URLCONF``. List can be empty if no url
+  configuration is needed or it can be omitted.
 
   Each entry in the list must be in the ``[<patten>,<include-dotted-path>]`` format:
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -76,3 +76,22 @@ def addon_config() -> Dict[str, Any]:
         "urls": [["", "djangocms_blog.taggit_urls"]],
         "message": "Please check documentation to complete the setup",
     }
+
+
+@pytest.fixture
+def addon_config_minimal() -> Dict[str, Any]:
+    """Minimal addon config."""
+    return {
+        "package-name": "djangocms-blog",
+        "installed-apps": [
+            "filer",
+            "easy_thumbnails",
+            "aldryn_apphooks_config",
+            "parler",
+            "taggit",
+            "taggit_autosuggest",
+            "meta",
+            "djangocms_blog",
+            "sortedm2m",
+        ],
+    }

--- a/tests/sample/test_project/urls.py
+++ b/tests/sample/test_project/urls.py
@@ -14,8 +14,10 @@ Including another URLconf
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 from django.contrib import admin
+from django.contrib.sitemaps.views import sitemap
 from django.urls import path
 
 urlpatterns = [
+    path("sitemap.xml", sitemap, {"sitemaps": {}}),
     path("admin/", admin.site.urls),
 ]

--- a/tests/test_enable.py
+++ b/tests/test_enable.py
@@ -9,7 +9,7 @@ from tests.utils import working_directory
 
 
 def test_enable(capsys, pytester, project_dir, addon_config, teardown_django):
-    """Executing setup_django will setup the corresponding django project."""
+    """Enabling application load the addon configuration in settings and urlconf."""
 
     with working_directory(project_dir), patch("app_enabler.enable.load_addon") as load_addon:
         load_addon.return_value = addon_config
@@ -30,8 +30,30 @@ def test_enable(capsys, pytester, project_dir, addon_config, teardown_django):
         assert _verify_urlconf(imported, addon_config)
 
 
+def test_enable_minimal(capsys, pytester, project_dir, addon_config_minimal, teardown_django):
+    """Enabling application load the addon configuration in settings and urlconf - minimal addon config."""
+
+    with working_directory(project_dir), patch("app_enabler.enable.load_addon") as load_addon:
+        load_addon.return_value = addon_config_minimal
+        os.environ["DJANGO_SETTINGS_MODULE"] = "test_project.settings"
+
+        enable("djangocms_blog")
+
+        captured = capsys.readouterr()
+        assert not captured.out
+        if os.environ["DJANGO_SETTINGS_MODULE"] in sys.modules:
+            del sys.modules[os.environ["DJANGO_SETTINGS_MODULE"]]
+        if "test_project.urls" in sys.modules:
+            del sys.modules["test_project.urls"]
+        imported = import_module(os.environ["DJANGO_SETTINGS_MODULE"])
+        assert _verify_settings(imported, addon_config_minimal)
+
+        imported = import_module("test_project.urls")
+        assert _verify_urlconf(imported, addon_config_minimal)
+
+
 def test_enable_no_application(pytester, project_dir, addon_config, teardown_django):
-    """Executing setup_django will setup the corresponding django project."""
+    """Enabling application with empty addon configuration does not alter the configuration."""
 
     with working_directory(project_dir), patch("app_enabler.enable.load_addon") as load_addon:
         load_addon.return_value = None
@@ -50,7 +72,8 @@ def test_enable_no_application(pytester, project_dir, addon_config, teardown_dja
         urlpattern_patched = False
         for urlpattern in imported.urlpatterns:
             if (
-                isinstance(urlpattern.urlconf_name, ModuleType)
+                getattr(urlpattern, "urlconf_name", None)
+                and isinstance(urlpattern.urlconf_name, ModuleType)
                 and urlpattern.urlconf_name.__name__ == "djangocms_blog.taggit_urls"
             ):
                 urlpattern_patched = True


### PR DESCRIPTION
# Description

- Fix error when addon config has no url, settings attributes
- Fix error when urlconf entry has no name

## References

Fix #17 

# Checklist

* [x] I have read the [contribution guide](https://django-app-enabler.readthedocs.io/en/latest/contributing.html)
* [x] Code lint checked via `inv lint`
* [x] ``changes`` file included (see [docs](https://django-app-enabler.readthedocs.io/en/latest/contributing.html#pull-request-guidelines))
* [x] Usage documentation added in case of new features
* [x] Tests added
