### PR TITLE
Fix importing include multiple times in urlconf

### DIFF
--- a/changes/21.bugfix
+++ b/changes/21.bugfix
@@ -1,0 +1,1 @@
+Fix importing include multiple times in urlconf


### PR DESCRIPTION
# Description

Check for already imported `include` function when patching urlconf

## References

Fix #21 

# Checklist

* [x] I have read the [contribution guide](https://django-app-enabler.readthedocs.io/en/latest/contributing.html)
* [x] Code lint checked via `inv lint`
* [x] ``changes`` file included (see [docs](https://django-app-enabler.readthedocs.io/en/latest/contributing.html#pull-request-guidelines))
* [x] Usage documentation added in case of new features
* [x] Tests added
