### PR TITLE
Close resource_stream file pointer

### DIFF
--- a/app_enabler/django.py
+++ b/app_enabler/django.py
@@ -16,8 +16,9 @@ def load_addon(module_name: str) -> Optional[Dict[str, Any]]:
     :return: addon configuration
     """
     try:
-        fp = resource_stream(module_name, "addon.json")
-        return json.load(fp)
+        with resource_stream(module_name, "addon.json") as fp:
+            data = json.load(fp)
+        return data
     except Exception:
         pass
 

--- a/changes/19.bugfix
+++ b/changes/19.bugfix
@@ -1,0 +1,1 @@
+Close resource_stream file pointer


### PR DESCRIPTION
# Description

Treat `resource_stream` like a file open function to close file pointer after usage

## References

Fix #19 

# Checklist

* [x] I have read the [contribution guide](https://django-app-enabler.readthedocs.io/en/latest/contributing.html)
* [x] Code lint checked via `inv lint`
* [x] ``changes`` file included (see [docs](https://django-app-enabler.readthedocs.io/en/latest/contributing.html#pull-request-guidelines))
* [x] Usage documentation added in case of new features
* [x] Tests added
