### PR TITLE
Add test to verify urlconf patching

### DIFF
--- a/app_enabler/patcher.py
+++ b/app_enabler/patcher.py
@@ -101,8 +101,8 @@ def update_setting(project_setting: str, config: Dict[str, Any]):
 
     src = astor.to_source(parsed)
 
-    with open(project_setting, "w") as settings:
-        settings.write(src)
+    with open(project_setting, "w") as fp:
+        fp.write(src)
 
 
 def update_urlconf(project_urls: str, config: Dict[str, Any]):
@@ -147,5 +147,5 @@ def update_urlconf(project_urls: str, config: Dict[str, Any]):
 
     src = astor.to_source(parsed)
 
-    with open(project_urls, "w") as settings:
-        settings.write(src)
+    with open(project_urls, "w") as fp:
+        fp.write(src)

--- a/changes/25.bugfix
+++ b/changes/25.bugfix
@@ -1,0 +1,1 @@
+Add test to verify no multiple urlconf are added

--- a/tests/sample/test_project/urls.py
+++ b/tests/sample/test_project/urls.py
@@ -13,11 +13,21 @@ Including another URLconf
     1. Import the include() function: from django.urls import include, path
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
+from django.conf.urls.i18n import i18n_patterns
 from django.contrib import admin
 from django.contrib.sitemaps.views import sitemap
 from django.urls import path
+from django.views import View
 
 urlpatterns = [
     path("sitemap.xml", sitemap, {"sitemaps": {}}),
     path("admin/", admin.site.urls),
 ]
+
+urlpatterns += [
+    path("something/", View.as_view()),
+]
+
+urlpatterns += i18n_patterns(
+    path("something/", View.as_view()),
+)


### PR DESCRIPTION
# Description

Add test to verify urlconf patching:
- application urlconf are added once
- existing urlconf entries are preserved even when multiple urlpatterns exists
## References

Fix #25 

# Checklist

* [x] I have read the [contribution guide](https://django-app-enabler.readthedocs.io/en/latest/contributing.html)
* [x] Code lint checked via `inv lint`
* [x] ``changes`` file included (see [docs](https://django-app-enabler.readthedocs.io/en/latest/contributing.html#pull-request-guidelines))
* [x] Usage documentation added in case of new features
* [x] Tests added
