### PR TITLE
Add support for external configuration json

### DIFF
--- a/app_enabler/cli.py
+++ b/app_enabler/cli.py
@@ -1,10 +1,12 @@
 import os
 import sys
+from pathlib import Path
 from subprocess import CalledProcessError
+from typing import List
 
 import click
 
-from .enable import enable as enable_fun
+from .enable import apply_configuration_set, enable_application as enable_fun
 from .errors import messages
 from .install import get_application_from_package, install as install_fun
 
@@ -36,6 +38,22 @@ def enable(context: click.core.Context, application: str):
     :param str application: python module name to enable. It must be the name of a Django application.
     """
     enable_fun(application, verbose=context.obj["verbose"])
+
+
+@cli.command()
+@click.argument("config_set", nargs=-1)
+@click.pass_context
+def apply(context: click.core.Context, config_set: List[str]):
+    """
+    Apply configuration stored in one or more json files.
+
+    CONFIG_SET: Path to configuration files
+    \f
+
+    :param click.core.Context context: Click context
+    :param list config_set: list of paths to addon configuration to load and apply
+    """
+    apply_configuration_set([Path(config) for config in config_set], verbose=context.obj["verbose"])
 
 
 @cli.command()

--- a/app_enabler/enable.py
+++ b/app_enabler/enable.py
@@ -8,6 +8,7 @@ from typing import Any, Dict, List
 import django.conf
 
 from .django import get_settings_path, get_urlconf_path, load_addon
+from .errors import messages
 from .patcher import setup_django, update_setting, update_urlconf
 
 
@@ -100,6 +101,8 @@ def apply_configuration(application_config: Dict[str, Any]):
     update_urlconf(urlconf_file, application_config)
     if verify_installation(django.conf.settings, application_config):
         output_message(application_config.get("message", ""))
+    else:
+        output_message(messages["verify_error"].format(package=application_config.get("package-name")))
 
 
 def enable_application(application: str, verbose: bool = False):

--- a/app_enabler/errors.py
+++ b/app_enabler/errors.py
@@ -2,4 +2,5 @@ messages = {
     "no_managepy": "app-enabler must be executed in the same directory as the project manage.py file",
     "install_error": "Package {package} not installable in the current virtualenv",
     "enable_error": "Package {package} not installed in the current virtualenv",
+    "verify_error": "Error verifying {package} configuration",
 }

--- a/app_enabler/patcher.py
+++ b/app_enabler/patcher.py
@@ -81,7 +81,7 @@ def update_setting(project_setting: str, config: Dict[str, Any]):
     parsed = astor.parse_file(project_setting)
     existing_setting = []
     addon_settings = config.get("settings", {})
-    addon_installed_apps = config["installed-apps"]
+    addon_installed_apps = config.get("installed-apps", [])
     for node in parsed.body:
         if isinstance(node, ast.Assign) and node.targets[0].id == "INSTALLED_APPS":
             installed_apps = [name.s for name in node.value.elts]

--- a/changes/9.feature
+++ b/changes/9.feature
@@ -1,0 +1,1 @@
+Add support for external configuration json

--- a/docs/addon_configuration.rst
+++ b/docs/addon_configuration.rst
@@ -24,6 +24,18 @@ the minimal setup to make the application up an running on a clean django projec
 .. warning:: The file must be included in root of the first (alphabetically) module of your application package.
              See :ref:`packaging` for details.
 
+.. _extra_json:
+
+****************************************
+Extra configuration files specifications
+****************************************
+
+Extra configuration files (applied via :ref:`apply_cmd`) must conform to the same specifications below with two exceptions:
+
+- all attributes are optional (i.e.: they can be completely omitted)
+- the json file can contain a single object like for the ``addon.json`` case, or a list of objects conforming to the specifications.
+
+
 Attributes
 ===========
 

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -4,21 +4,26 @@
 API
 ###
 
+********
+Commands
+********
+
+.. click:: app_enabler.cli:cli
+  :prog: django-enabler
+  :show-nested:
+
 *******
 CLI
 *******
 
 .. automodule:: app_enabler.cli
     :members:
-    :private-members:
 
 .. automodule:: app_enabler.enable
     :members:
-    :private-members:
 
 .. automodule:: app_enabler.install
     :members:
-    :private-members:
 
 *******
 Loaders
@@ -26,7 +31,6 @@ Loaders
 
 .. automodule:: app_enabler.django
     :members:
-    :private-members:
 
 ********
 Patchers
@@ -34,4 +38,3 @@ Patchers
 
 .. automodule:: app_enabler.patcher
     :members:
-    :private-members:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -41,6 +41,7 @@ extensions = [
     "sphinx.ext.coverage",
     "sphinx.ext.ifconfig",
     "sphinx.ext.viewcode",
+    "sphinx_click.ext",
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/todo.rst
+++ b/docs/todo.rst
@@ -8,7 +8,6 @@ Planned features
 * Support extra-requirements `issue-6`_
 * Support Django settings split in multiple files `issue-7`_
 * Support Django urlconf split in multiple files `issue-8`_
-* Add support for external addon.json `issue-9`_
 
 
 
@@ -17,4 +16,3 @@ Planned features
 .. _issue-6: https://github.com/nephila/django-app-enabler/issues/6
 .. _issue-7: https://github.com/nephila/django-app-enabler/issues/7
 .. _issue-8: https://github.com/nephila/django-app-enabler/issues/8
-.. _issue-9: https://github.com/nephila/django-app-enabler/issues/9

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -18,6 +18,7 @@ Installation
 Commands
 *************************
 
+* :ref:`apply \<path_to_json\> \<path_to_json\> <apply_cmd>`: Apply configuration from json files
 * :ref:`enable \<module_name\> <enable_cmd>`: Configure an application
 * :ref:`install \<package-name\> <install_cmd>`: Install and configure an application
 
@@ -62,6 +63,30 @@ Example:
 .. code-block:: bash
 
     django-enabler enable djangocms_blog
+
+
+See :ref:`limitations` for limitations and caveats.
+
+
+.. _apply_cmd:
+
+*************************
+Apply configurations
+*************************
+
+``django-app-enabler`` can also apply configuration from arbitrary json files not included in any Django application.
+
+Each configuration file must comply with :ref:`extra_json`.
+
+.. note:: Django ``settings`` and ``urlconf`` are patched unconditionally.
+          No attempt to verify that applications declared in ``installed_apps``
+          or added to the ``urlconf`` are available in the virtualenv is made.
+
+Example:
+
+.. code-block:: bash
+
+    django-enabler apply /path/to/config1.json /path/to/config2.json
 
 
 See :ref:`limitations` for limitations and caveats.

--- a/setup.cfg
+++ b/setup.cfg
@@ -68,6 +68,7 @@ app_enabler = *.html *.png *.gif *js *jpg *jpeg *svg *py *mo *po
 [options.extras_require]
 docs =
 	django<3.1
+    sphinx-click
 
 [options.entry_points]
 console_scripts =

--- a/tests/sample/config/1.json
+++ b/tests/sample/config/1.json
@@ -1,0 +1,25 @@
+[
+  {
+    "installed-apps": [
+      "taggit"
+    ],
+    "settings": {
+      "MY_SETTING_A": "some_value"
+    },
+    "urls": [
+      [
+        "",
+        "djangocms_blog.taggit_urls"
+      ]
+    ],
+    "message": "json1-a"
+  },
+  {
+    "installed-apps": [
+    ],
+    "settings": {
+      "MY_SETTING_B": "some_value"
+    },
+    "message": "json1-b"
+  }
+]

--- a/tests/sample/config/2.json
+++ b/tests/sample/config/2.json
@@ -1,0 +1,6 @@
+{
+  "settings": {
+    "MY_SETTING_2": "some_value"
+  },
+  "message": "json2"
+}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,6 @@
 import os
 import sys
+from pathlib import Path
 from subprocess import CalledProcessError
 from unittest.mock import call, patch
 
@@ -119,6 +120,25 @@ def test_cli_enable(verbose: bool):
 
         enable_fun.assert_called_once()
         assert enable_fun.call_args_list == [call("djangocms_blog", verbose=verbose)]
+
+
+@pytest.mark.parametrize("verbose", (True, False))
+def test_cli_apply(verbose: bool):
+    """Running apply command calls the business functions with the correct arguments."""
+    with patch("app_enabler.cli.apply_configuration_set") as apply_configuration_set:
+        runner = CliRunner()
+        if verbose:
+            args = ["--verbose"]
+        else:
+            args = []
+
+        configs = ("/path/config1.json", "/path/config2.json")
+        args.extend(("apply", *configs))
+        result = runner.invoke(cli, args)
+        assert result.exit_code == 0
+
+        apply_configuration_set.assert_called_once()
+        assert apply_configuration_set.call_args_list == [call([Path(config) for config in configs], verbose=verbose)]
 
 
 @pytest.mark.parametrize("verbose", (True, False))

--- a/tests/test_enable.py
+++ b/tests/test_enable.py
@@ -1,10 +1,11 @@
+import json
 import os
 import sys
 from importlib import import_module
 from types import ModuleType
 from unittest.mock import patch
 
-from app_enabler.enable import _verify_settings, _verify_urlconf, enable
+from app_enabler.enable import _verify_settings, _verify_urlconf, apply_configuration_set, enable_application
 from tests.utils import working_directory
 
 
@@ -15,7 +16,7 @@ def test_enable(capsys, pytester, project_dir, addon_config, teardown_django):
         load_addon.return_value = addon_config
         os.environ["DJANGO_SETTINGS_MODULE"] = "test_project.settings"
 
-        enable("djangocms_blog")
+        enable_application("djangocms_blog")
 
         captured = capsys.readouterr()
         assert addon_config["message"] in captured.out
@@ -37,7 +38,7 @@ def test_enable_minimal(capsys, pytester, project_dir, addon_config_minimal, tea
         load_addon.return_value = addon_config_minimal
         os.environ["DJANGO_SETTINGS_MODULE"] = "test_project.settings"
 
-        enable("djangocms_blog")
+        enable_application("djangocms_blog")
 
         captured = capsys.readouterr()
         assert not captured.out
@@ -59,7 +60,7 @@ def test_enable_no_application(pytester, project_dir, addon_config, teardown_dja
         load_addon.return_value = None
         os.environ["DJANGO_SETTINGS_MODULE"] = "test_project.settings"
 
-        enable("djangocms_blog")
+        enable_application("djangocms_blog")
         if os.environ["DJANGO_SETTINGS_MODULE"] in sys.modules:
             del sys.modules[os.environ["DJANGO_SETTINGS_MODULE"]]
         if "test_project.urls" in sys.modules:
@@ -78,3 +79,36 @@ def test_enable_no_application(pytester, project_dir, addon_config, teardown_dja
             ):
                 urlpattern_patched = True
         assert not urlpattern_patched
+
+
+def test_apply_configuration_set(capsys, pytester, project_dir, teardown_django):
+    """Applying configurations from a list of json files update the project settings and urlconf."""
+
+    with working_directory(project_dir):
+        sample_config_set = [
+            project_dir / "config" / "1.json",
+            project_dir / "config" / "2.json",
+            project_dir / "config" / "no_file.json",
+        ]
+        os.environ["DJANGO_SETTINGS_MODULE"] = "test_project.settings"
+
+        json_configs = [json.loads(path.read_text()) for path in sample_config_set if path.exists()]
+
+        apply_configuration_set(sample_config_set)
+
+        captured = capsys.readouterr()
+        assert "json1-a" in captured.out
+        assert "json1-b" in captured.out
+        assert "json2" in captured.out
+        if os.environ["DJANGO_SETTINGS_MODULE"] in sys.modules:
+            del sys.modules[os.environ["DJANGO_SETTINGS_MODULE"]]
+        if "test_project.urls" in sys.modules:
+            del sys.modules["test_project.urls"]
+        imported_settings = import_module(os.environ["DJANGO_SETTINGS_MODULE"])
+        imported_urls = import_module("test_project.urls")
+        for config in json_configs:
+            if not isinstance(config, list):
+                config = [config]
+            for item in config:
+                assert _verify_settings(imported_settings, item)
+                assert _verify_urlconf(imported_urls, item)

--- a/tox.ini
+++ b/tox.ini
@@ -83,6 +83,7 @@ deps =
     sphinx
     sphinx-rtd-theme
     sphinx-autobuild
+    sphinx-click
     livereload~=2.6
     -rrequirements-test.txt
 skip_install = true


### PR DESCRIPTION
# Description

Add new apply command to pass a list of json files outside applications

This allow to both configure external applications and to just patch a project with a set of settings

## References

Fix #9

# Checklist

* [x] I have read the [contribution guide](https://django-app-enabler.readthedocs.io/en/latest/contributing.html)
* [x] Code lint checked via `inv lint`
* [x] ``changes`` file included (see [docs](https://django-app-enabler.readthedocs.io/en/latest/contributing.html#pull-request-guidelines))
* [x] Usage documentation added in case of new features
* [x] Tests added
