### PR TITLE
Fix docs build, drop support for Django < 4.2 and python < 3.10

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,8 +8,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.11", "3.10", "3.9"]
-        django: [42, 41, 32]
+        python-version: ["3.11", "3.10"]
+        django: [42]
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}

--- a/changes/64.bugfix
+++ b/changes/64.bugfix
@@ -1,0 +1,1 @@
+Fix docs build

--- a/changes/64.bugfix
+++ b/changes/64.bugfix
@@ -1,1 +1,1 @@
-Fix docs build
+Fix docs build, drop support for Django < 4.2 and python < 3.10

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,10 +15,6 @@
 import os
 import sys
 
-# The theme to use for HTML and HTML Help pages.  See the documentation for
-# a list of builtin themes.
-import sphinx_rtd_theme
-
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
@@ -113,7 +109,6 @@ pygments_style = "sphinx"
 
 html_theme = "sphinx_rtd_theme"
 
-html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,13 +17,8 @@ classifiers =
 	Intended Audience :: Developers
 	Natural Language :: English
 	Framework :: Django
-	Framework :: Django :: 3.2
-	Framework :: Django :: 4.0
-	Framework :: Django :: 4.1
 	Framework :: Django :: 4.2
 	Programming Language :: Python :: 3
-	Programming Language :: Python :: 3.8
-	Programming Language :: Python :: 3.9
 	Programming Language :: Python :: 3.10
 	Programming Language :: Python :: 3.11
 
@@ -35,7 +30,7 @@ install_requires =
 setup_requires =
 	setuptools
 packages = app_enabler
-python_requires = >=3.8
+python_requires = >=3.10
 test_suite = pytest
 zip_safe = False
 

--- a/tox.ini
+++ b/tox.ini
@@ -8,16 +8,13 @@ envlist =
     ruff
     pypi-description
     towncrier
-    py{311,310,39}-django{42,41,40,32}
+    py{311,310}-django{42}
 
 [testenv]
 alwayscopy = True
 commands =
     {env:COMMAND:python} -mpytest {posargs} {env:PYTEST_ARGS:""}
 deps =
-    django32: Django~=3.2.0
-    django40: Django~=4.0.0
-    django41: Django~=4.1.0
     django42: Django~=4.2.0
     -r{toxinidir}/requirements-test.txt
 passenv =


### PR DESCRIPTION
# Description

Fix docs build, drop support for Django < 4.2 and python < 3.10

## References

Fix #64 

# Checklist

* [x] I have read the [contribution guide](https://django-app-enabler.readthedocs.io/en/latest/contributing.html)
* [x] Code lint checked via `inv lint`
* [x] ``changes`` file included (see [docs](https://django-app-enabler.readthedocs.io/en/latest/contributing.html#pull-request-guidelines))
* [ ] Usage documentation added in case of new features
* [ ] Tests added
